### PR TITLE
Update signatory version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ name = "nk"
 required-features = ["cli"]
 
 [dependencies]
-signatory = "0.16.0"
-signatory-dalek = "0.16.0"
-ed25519-dalek = { version = "1.0.0-pre.3", features = ["std"] }
+signatory = "0.17.0"
+signatory-dalek = "0.17.0"
+ed25519-dalek = { version = "1.0.0-pre.2", features = ["std"] }
 
 rand = "0.7.2"
 byteorder = "1.3.2"


### PR DESCRIPTION
Version `0.16` of `signatory` fails to compile on Windows because of this error: https://github.com/tendermint/signatory/issues/180 and prevents compilation of this crate too.

I also had to change `ed25519-dalek` to "1.0.0-pre.2" instead of pre.3 because of semver conflicts in `signatory-dalek`. 