### PR TITLE
Fix compilation error (and remove unused import)

### DIFF
--- a/src/crc.rs
+++ b/src/crc.rs
@@ -30,7 +30,7 @@ pub(crate) fn crc16(data: &[u8]) -> u16 {
     let mut crc = 0_u16;
     for b in data {
         let idx = ((crc >> 8) ^ *b as u16) & 0x00FF;
-        crc = ((crc << 8) & 0xFFFF) ^ CRC_TABLE[idx as usize];
+        crc = (crc << 8) ^ CRC_TABLE[idx as usize];
     }
     crc
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ use rand::prelude::*;
 use signatory::ed25519;
 use signatory::ed25519::PublicKey;
 use signatory::public_key::PublicKeyed;
-use signatory::signature::{Signature, Signer, Verifier};
+use signatory::signature::{Signer, Verifier};
 use signatory_dalek::{Ed25519Signer, Ed25519Verifier};
 use std::fmt;
 use std::fmt::Debug;
@@ -207,7 +207,7 @@ impl KeyPair {
             let signer = Ed25519Signer::from(seed);
             //let sig = signatory::ed25519::sign(&signer, input)?;
             let sig = signer.sign(input);
-            Ok(sig.as_slice().to_vec())
+            Ok(sig.to_bytes().to_vec())
         } else {
             Err(err!(SignatureError, "Cannot sign without a seed key"))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,28 +11,26 @@
 //! ```
 //! use nkeys::KeyPair;
 //!
-//! fn main() {
-//!     // Create a user key pair
-//!     let user = KeyPair::new_user();
+//! // Create a user key pair
+//! let user = KeyPair::new_user();
 //!
-//!     // Sign some data with the user's full key pair
-//!     let msg = "this is super secret".as_bytes();
-//!     let sig = user.sign(&msg).unwrap();
-//!     let res = user.verify(msg, sig.as_slice());
-//!     assert!(res.is_ok());
+//! // Sign some data with the user's full key pair
+//! let msg = "this is super secret".as_bytes();
+//! let sig = user.sign(&msg).unwrap();
+//! let res = user.verify(msg, sig.as_slice());
+//! assert!(res.is_ok());
 //!
-//!     // Access the encoded seed (the information that needs to be kept safe/secret)
-//!     let seed = user.seed().unwrap();
-//!     // Access the public key, which can be safely shared
-//!     let pk = user.public_key();
+//! // Access the encoded seed (the information that needs to be kept safe/secret)
+//! let seed = user.seed().unwrap();
+//! // Access the public key, which can be safely shared
+//! let pk = user.public_key();
 //!
-//!     // Create a full User who can sign and verify from a private seed.
-//!     let user = KeyPair::from_seed(&seed);
+//! // Create a full User who can sign and verify from a private seed.
+//! let user = KeyPair::from_seed(&seed);
 //!
-//!     // Create a user that can only verify and not sign
-//!     let user = KeyPair::from_public_key(&pk).unwrap();
-//!     assert!(user.seed().is_err());
-//! }
+//! // Create a user that can only verify and not sign
+//! let user = KeyPair::from_public_key(&pk).unwrap();
+//! assert!(user.seed().is_err());
 //! ```
 
 #![allow(dead_code)]


### PR DESCRIPTION
Closes https://github.com/encabulators/nkeys/issues/2.

The error (and warning) were:

```
error[E0599]: no method named `as_slice` found for type `ed25519::Signature` in the current scope
   --> src/lib.rs:210:20
    |
210 |             Ok(sig.as_slice().to_vec())
    |                    ^^^^^^^^ method not found in `ed25519::Signature`

warning: unused import: `Signature`
  --> src/lib.rs:45:28
   |
45 | use signatory::signature::{Signature, Signer, Verifier};
   |                            ^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

```

```console
$ cargo test
   Compiling nkeys v0.0.8 (/home/kit/wrk/src/github.com/encabulators/nkeys)
    Finished test [unoptimized + debuginfo] target(s) in 1.59s
     Running target/debug/deps/nkeys-d5ef330318d89d16

running 9 tests
test tests::from_seed_rejects_bad_prefix ... ok
test tests::from_seed_rejects_bad_length ... ok
test tests::from_seed_rejects_invalid_encoding ... ok
test tests::module_has_proper_prefix ... ok
test tests::public_key_round_trip ... ok
test tests::roundtrip_encoding_go_compat ... ok
test tests::sign_and_verify ... ok
test tests::seed_encode_decode_round_trip ... ok
test tests::sign_and_verify_rejects_mismatched_sig ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests nkeys

running 1 test
test src/lib.rs -  (line 11) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```