### PR TITLE
Add support for json output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography", "authentication"]
 travis-ci = { repository = "encabulators/nkeys", branch = "master" }
 
 [features]
-cli = ["quicli", "structopt", "term-table", "exitfailure", "env_logger"]
+cli = ["quicli", "structopt", "term-table", "exitfailure", "env_logger", "serde_json"]
 
 [[bin]]
 name = "nk"
@@ -38,8 +38,4 @@ structopt = { version = "0.3.11", optional = true }
 term-table = { version = "1.2.0", optional = true }
 exitfailure = { version = "0.5.1", optional =true }
 env_logger = { version = "0.7.1", optional = true }
-
-
-
-
-
+serde_json = { version = "1.0", optional = true }


### PR DESCRIPTION
This adds a new flag to the `gen` command in `nk` called `--output`. It
takes one of two parameters:
* `text` (default): the current human-readable format
* `json`: formats the key and seed in JSON so that they can be fed to
  other programs via stdin.
  The message is pretty straightforward:

  ```json
  {
    "private_key": "A...",
    "seed": "S..."
  }
  ```