### PR TITLE
feat(*): Adds support for wasm32 targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 .idea
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "nkeys"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "Rust implementation of the NATS nkeys library"
 license = "Apache-2.0"
 homepage = "https://github.com/encabulators/nkeys"
@@ -23,9 +23,9 @@ name = "nk"
 required-features = ["cli"]
 
 [dependencies]
-signatory = "0.21"
+signatory = "0.23"
 ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend"] }
-rand = "0.7.3"
+rand = "0.8"
 byteorder = "1.3.4"
 data-encoding = "2.3.0"
 log = "0.4.11"
@@ -35,5 +35,10 @@ quicli = { version = "0.4", optional = true }
 structopt = { version = "0.3.17", optional = true }
 term-table = { version = "1.3.0", optional = true }
 exitfailure = { version = "0.5.1", optional =true }
-env_logger = { version = "0.7.1", optional = true }
+env_logger = { version = "0.9", optional = true }
 serde_json = { version = "1.0", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# DIRTY HACK WARNING: We don't actually use this, but if we don't specify custom, things die because
+# wasm32-unknown-unknown isn't supported
+getrandom = { version = "0.2", default-features = false, features = ["custom"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,16 @@
 [package]
 name = "nkeys"
 version = "0.2.0"
-authors = ["Kevin Hoffman <alothien@gmail.com>"]
+authors = ["wasmCloud Team"]
 edition = "2021"
 description = "Rust implementation of the NATS nkeys library"
 license = "Apache-2.0"
-homepage = "https://github.com/encabulators/nkeys"
+homepage = "https://github.com/wasmcloud/nkeys"
 documentation = "https://docs.rs/nkeys"
-repository = "https://github.com/encabulators/nkeys"
+repository = "https://github.com/wasmcloud/nkeys"
 readme = "README.md"
 keywords = ["crypto", "nats", "ed25519", "cryptography"]
 categories = ["cryptography", "authentication"]
-
-[badges]
-travis-ci = { repository = "encabulators/nkeys", branch = "master" }
 
 [features]
 cli = ["quicli", "structopt", "term-table", "exitfailure", "env_logger", "serde_json"]
@@ -39,6 +36,10 @@ env_logger = { version = "0.9", optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-# DIRTY HACK WARNING: We don't actually use this, but if we don't specify custom, things die because
-# wasm32-unknown-unknown isn't supported
+# NOTE: We need this due to an underlying dependency being pulled in by
+# `ed25519-dalek`. Even if we exclude `rand`, that crate pulls it in. `rand` pulls in the low level
+# `getrandom` library, which explicitly doesn't support wasm32-unknown-unknown. This is a hack to
+# get around that by enabling the `custom` feature of getrandom (even though we don't actually use
+# the library). This makes `rand` compile in the dalek library even though we aren't actually using
+# the `rand` part of it.
 getrandom = { version = "0.2", default-features = false, features = ["custom"] }

--- a/src/bin/nk/main.rs
+++ b/src/bin/nk/main.rs
@@ -39,7 +39,7 @@ enum Command {
 #[derive(StructOpt, Debug, Clone)]
 enum Output {
     Text,
-    JSON,
+    Json,
 }
 
 impl FromStr for Output {
@@ -47,7 +47,7 @@ impl FromStr for Output {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "json" => Ok(Output::JSON),
+            "json" => Ok(Output::Json),
             "text" => Ok(Output::Text),
             _ => Err(OutputParseErr),
         }
@@ -63,7 +63,6 @@ impl fmt::Display for OutputParseErr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{}",
             "error parsing output type, see help for the list of accepted outputs"
         )
     }
@@ -91,7 +90,7 @@ fn generate(kt: &KeyPairType, output_type: &Output) {
                 kp.seed().unwrap()
             );
         }
-        Output::JSON => {
+        Output::Json => {
             let output = json!({
                 "public_key": kp.public_key(),
                 "seed": kp.seed().unwrap(),


### PR DESCRIPTION
This will allow anyone who wants to use the nkeys library in a `wasm32-unknown-unknown`
target to do so (such as in wasmcloud actors). It also enables users
to generate their keys using different sources of random data