### PR TITLE
Derive PartialEq for KeyPairType

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ impl Debug for KeyPair {
 
 /// The authoritative list of valid key pair types that are used for cryptographically secure
 /// identities
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum KeyPairType {
     /// A server identity
     Server,


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

I want to compare key types.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

None.

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

`next`

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

Consumers can compare key types.

## Testing
<!---
Declare the testing information for this pull request
--->

I have checked the code with `cargo test` and `cargo clippy`.

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [x] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [x] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

I have not added any tests.

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

I have not changed the acceptance or integration test suites.

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

I have checked the code with `cargo test` and `cargo clippy` using Rust 1.69.0.
