### PR TITLE
Add `key_pair_type` method to `KeyPair`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,6 +343,11 @@ impl KeyPair {
             })
         }
     }
+
+    /// Returns the type of this key pair.
+    pub fn key_pair_type(&self) -> KeyPairType {
+        self.kp_type.clone()
+    }
 }
 
 fn pk_from_seed(seed: &SecretKey) -> PublicKey {
@@ -506,6 +511,29 @@ mod tests {
         let service = KeyPair::new_service();
         assert!(service.seed().unwrap().starts_with("SV"));
         assert!(service.public_key().starts_with('V'));
+    }
+
+    #[test]
+    fn can_get_key_type() {
+        let from_pub =
+            KeyPair::from_public_key("UBCXCMGAZQZN55X5TTTWMB5CZNZIKJHEDZJOJ3TV63NKPJ6FRXSR2ZO4")
+                .unwrap();
+        let from_seed =
+            KeyPair::from_seed("SCANU5JGFEPJ2XNFQ6YMDRHMNFAL6ZT3DCU3ZMMHHML7GLFE3YIH5TBM6E")
+                .unwrap();
+
+        assert!(
+            matches!(from_pub.key_pair_type(), KeyPairType::User),
+            "Expected the key type to be {:?}, found {:?}",
+            KeyPairType::User,
+            from_pub.key_pair_type()
+        );
+        assert!(
+            matches!(from_seed.key_pair_type(), KeyPairType::Cluster),
+            "Expected the key type to be {:?}, found {:?}",
+            KeyPairType::Cluster,
+            from_seed.key_pair_type()
+        );
     }
 }
 


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

I am interested in checking the type of an existing key.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

None.

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

`next`

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

Consumers can check the type of a key.

## Testing
<!---
Declare the testing information for this pull request
--->

I have checked the code with `cargo test` and `cargo clippy`.

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [x] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [x] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

I have added one unit test, `crate::tests::can_get_key_type`.

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

I have not changed the acceptance or integration test suites.

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

I have checked the code with `cargo test` and `cargo clippy` using Rust 1.69.0.
