### PR TITLE
Bumped to 0.3.0, added CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# wasmcloud team members
+* @autodidaddict @brooksmtownsend @thomastaylor312
+
+# wasmcloud devops
+/.github/workflows/ @brooksmtownsend

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nkeys"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["wasmCloud Team"]
 edition = "2021"
 description = "Rust implementation of the NATS nkeys library"


### PR DESCRIPTION
## Feature or Problem
Bumps to `0.3.0` after #14 and #15. Also adds CODEOWNERS so we get requested for reviews

## Related Issues
See above

## Release Information
0.3.0

## Consumer Impact
Consumers of 0.3.0 will be able to compare KeyPairTypes and easily fetch the type from a keypair.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
