### PR TITLE
Chore: bump to 0.3.1 to fix failing build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nkeys"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["wasmCloud Team"]
 edition = "2021"
 description = "Rust implementation of the NATS nkeys library"


### PR DESCRIPTION
## Feature or Problem
This PR just bumps to 0.3.1 so we can release a working build to crates.

## Related Issues
#17  / #18 

## Release Information
v0.3.1

## Consumer Impact
This introduces the ed25519 dependency but changes no public exports.

## Testing
It builds!

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
