### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,9 +20,9 @@ jobs:
           - { os: "windows-latest" }
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install latest Rust stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
           default: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,12 +15,11 @@ jobs:
     steps:
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: Release ${{ github.ref }}
           draft: false
           prerelease: true
 
@@ -29,7 +28,7 @@ jobs:
     needs: github_release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - id: crates-release-action
         uses: wasmcloud/common-actions/crates-release@main
         with:


### PR DESCRIPTION
- https://github.com/dtolnay/rust-toolchain should be a drop-in replacement for https://github.com/actions-rs/toolchain, which hasn't been maintained for a couple years
- https://github.com/softprops/action-gh-release is a replacement for https://github.com/actions/create-release, which has been archived for a few years