### PR TITLE
feat(xKeys): Add support for xKeys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ cli = [
     "serde_json",
 ]
 
+xkeys = ["dep:crypto_box"]
+
 [[bin]]
 name = "nk"
 required-features = ["cli"]
@@ -36,6 +38,7 @@ rand = "0.8"
 byteorder = "1.3.4"
 data-encoding = "2.3.0"
 log = "0.4.11"
+crypto_box = { version = "0.9.1", optional = true } # For xKeys support
 
 # CLI Dependencies
 quicli = { version = "0.4", optional = true }

--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ The following is a list of available prefixes and their keypair types:
 * **M** - Module
 * **V** - Service / Service Provider
 * **P** - Private Key
+* **X** - Curve Key (X25519)
 
 For seeds, the first encoded prefix is **S**, and the second character will be the type for the public key, e.g. `SU` is a seed for a user key pair, `SA` is a seed for an account key pair.

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,8 @@ pub enum ErrorKind {
     CodecFailure,
     /// Indicates a key type mismatch, e.g. attempting to sign with only a public key
     IncorrectKeyType,
+    /// Payload not valid (or failed to be decrypted)
+    InvalidPayload,
 }
 
 /// A handy macro borrowed from the `signatory` crate that lets library-internal code generate
@@ -67,6 +69,7 @@ impl ErrorKind {
             ErrorKind::CodecFailure => "Codec failure",
             ErrorKind::SignatureError => "Signature failure",
             ErrorKind::IncorrectKeyType => "Incorrect key type",
+            ErrorKind::InvalidPayload => "Invalid payload",
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@
 //! * **M** - Module
 //! * **V** - Service / Service Provider
 //! * **P** - Private Key
+//! * **X** - Curve Key (X25519)
 
 #![allow(dead_code)]
 
@@ -50,6 +51,12 @@ use std::fmt::{self, Debug};
 use crc::{extract_crc, push_crc, valid_checksum};
 use ed25519_dalek::{SecretKey, Signer, SigningKey, Verifier, VerifyingKey};
 use rand::prelude::*;
+
+#[cfg(feature = "xkeys")]
+mod xkeys;
+
+#[cfg(feature = "xkeys")]
+pub use xkeys::XKey;
 
 const ENCODED_SEED_LENGTH: usize = 58;
 
@@ -62,9 +69,10 @@ const PREFIX_BYTE_MODULE: u8 = 12 << 3;
 const PREFIX_BYTE_ACCOUNT: u8 = 0;
 const PREFIX_BYTE_USER: u8 = 20 << 3;
 const PREFIX_BYTE_SERVICE: u8 = 21 << 3;
-const PREFIX_BYTE_UNKNOWN: u8 = 23 << 3;
+const PREFIX_BYTE_CURVE: u8 = 23 << 3;
+const PREFIX_BYTE_UNKNOWN: u8 = 25 << 3;
 
-const PUBLIC_KEY_PREFIXES: [u8; 7] = [
+const PUBLIC_KEY_PREFIXES: [u8; 8] = [
     PREFIX_BYTE_ACCOUNT,
     PREFIX_BYTE_CLUSTER,
     PREFIX_BYTE_OPERATOR,
@@ -72,6 +80,7 @@ const PUBLIC_KEY_PREFIXES: [u8; 7] = [
     PREFIX_BYTE_USER,
     PREFIX_BYTE_MODULE,
     PREFIX_BYTE_SERVICE,
+    PREFIX_BYTE_CURVE,
 ];
 
 type Result<T> = std::result::Result<T, crate::error::Error>;
@@ -109,6 +118,8 @@ pub enum KeyPairType {
     Module,
     /// A service / service provider identity
     Service,
+    /// CurveKeys (X25519)
+    Curve,
 }
 
 impl std::str::FromStr for KeyPairType {
@@ -125,6 +136,7 @@ impl std::str::FromStr for KeyPairType {
             "USER" => Ok(KeyPairType::User),
             "SERVICE" => Ok(KeyPairType::Service),
             "MODULE" => Ok(KeyPairType::Module),
+            "CURVE" => Ok(KeyPairType::Curve),
             _ => Ok(KeyPairType::Module), // Do not crash the app if user input was wrong
         }
     }
@@ -140,6 +152,7 @@ impl From<u8> for KeyPairType {
             PREFIX_BYTE_USER => KeyPairType::User,
             PREFIX_BYTE_MODULE => KeyPairType::Module,
             PREFIX_BYTE_SERVICE => KeyPairType::Service,
+            PREFIX_BYTE_CURVE => KeyPairType::Curve,
             _ => KeyPairType::Operator,
         }
     }
@@ -235,12 +248,7 @@ impl KeyPair {
 
     /// Returns the encoded, human-readable public key of this key pair
     pub fn public_key(&self) -> String {
-        let mut raw = vec![get_prefix_byte(&self.kp_type)];
-
-        raw.extend(self.pk.as_bytes());
-
-        push_crc(&mut raw);
-        data_encoding::BASE32_NOPAD.encode(&raw[..])
+        encode(&self.kp_type, self.pk.as_bytes())
     }
 
     /// Attempts to sign the given input with the key pair's seed
@@ -270,18 +278,7 @@ impl KeyPair {
     /// any longer than necessary
     pub fn seed(&self) -> Result<String> {
         if let Some(ref seed) = self.sk {
-            let mut raw = vec![];
-            let prefix_byte = get_prefix_byte(&self.kp_type);
-
-            let b1 = PREFIX_BYTE_SEED | prefix_byte >> 5;
-            let b2 = (prefix_byte & 31) << 3;
-
-            raw.push(b1);
-            raw.push(b2);
-            raw.extend(seed.iter());
-            push_crc(&mut raw);
-
-            Ok(data_encoding::BASE32_NOPAD.encode(&raw[..]))
+            Ok(encode_seed(&self.kp_type, seed))
         } else {
             Err(err!(IncorrectKeyType, "This keypair has no seed"))
         }
@@ -380,11 +377,35 @@ fn get_prefix_byte(kp_type: &KeyPairType) -> u8 {
         KeyPairType::User => PREFIX_BYTE_USER,
         KeyPairType::Module => PREFIX_BYTE_MODULE,
         KeyPairType::Service => PREFIX_BYTE_SERVICE,
+        KeyPairType::Curve => PREFIX_BYTE_CURVE,
     }
 }
 
 fn valid_public_key_prefix(prefix: u8) -> bool {
     PUBLIC_KEY_PREFIXES.to_vec().contains(&prefix)
+}
+
+fn encode_seed(ty: &KeyPairType, seed: &[u8]) -> String {
+    let prefix_byte = get_prefix_byte(ty);
+
+    let b1 = PREFIX_BYTE_SEED | prefix_byte >> 5;
+    let b2 = (prefix_byte & 31) << 3;
+
+    encode_prefix(&[b1, b2], seed)
+}
+
+fn encode(ty: &KeyPairType, key: &[u8]) -> String {
+    let prefix_byte = get_prefix_byte(ty);
+    encode_prefix(&[prefix_byte], key)
+}
+
+fn encode_prefix(prefix: &[u8], key: &[u8]) -> String {
+    let mut raw = Vec::with_capacity(prefix.len() + key.len() + 2);
+    raw.extend_from_slice(prefix);
+    raw.extend_from_slice(key);
+    push_crc(&mut raw);
+
+    data_encoding::BASE32_NOPAD.encode(&raw[..])
 }
 
 #[cfg(test)]

--- a/src/xkeys.rs
+++ b/src/xkeys.rs
@@ -185,7 +185,9 @@ impl XKey {
         };
 
         let b = SalsaBox::new(&recipient.public, private_key);
-        let crypted = b.encrypt(&nonce, input).unwrap(); // Can't fail
+        let crypted = b
+            .encrypt(&nonce, input)
+            .map_err(|_| err!(SignatureError, "Cannot seal payload"))?; // Can't fail when used with SalsaBox
 
         let mut out = Vec::with_capacity(
             XKEY_VERSION_V1.len()

--- a/src/xkeys.rs
+++ b/src/xkeys.rs
@@ -1,0 +1,371 @@
+use crate::{
+    decode_raw, encode, encode_prefix, encode_seed, err, KeyPairType, ENCODED_SEED_LENGTH,
+    PREFIX_BYTE_CURVE, PREFIX_BYTE_PRIVATE, PREFIX_BYTE_SEED,
+};
+
+use super::Result;
+use crypto_box::{
+    aead::{Aead, AeadCore},
+    SalsaBox,
+};
+use ed25519::signature::digest::typenum::Unsigned;
+use std::fmt::{self, Debug};
+
+const XKEY_VERSION_V1: &[u8] = b"xkv1";
+
+use crypto_box::{PublicKey, SecretKey};
+use rand::{CryptoRng, Rng, RngCore};
+
+/// The main interface used for reading and writing _nkey-encoded_ curve key
+/// pairs. Instances of this type cannot be cloned.
+pub struct XKey {
+    public: PublicKey,
+    secret: Option<SecretKey>,
+}
+
+impl Debug for XKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "XKey")
+    }
+}
+
+impl XKey {
+    /// Creates a new xkey.
+    ///
+    /// NOTE: This is not available if using on a wasm32-unknown-unknown target due to the lack of
+    /// rand support. Use [`new_from_raw`](XKey::new_from_raw) instead
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn new() -> Self {
+        Self::new_with_rand(&mut rand::rngs::OsRng)
+    }
+
+    /// Create a new xkey pair from a random generator
+    ///
+    /// NOTE: These generator should be a cryptographically secure random source.
+    ///
+    /// NOTE: This is not available if using on a wasm32-unknown-unknown target due to the lack of
+    /// rand support. Use [`new_from_raw`](XKey::new_from_raw) instead
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn new_with_rand(rand: &mut (impl CryptoRng + RngCore)) -> Self {
+        Self::new_from_raw(rand.gen())
+    }
+
+    /// Create a new xkey pair using a pre-existing set of random bytes.
+    ///
+    /// NOTE: These bytes should be generated from a cryptographically secure random source.
+    pub fn new_from_raw(random_bytes: [u8; 32]) -> Self {
+        let private = SecretKey::from_bytes(random_bytes);
+        Self {
+            public: private.public_key(),
+            secret: Some(private),
+        }
+    }
+
+    /// Attempts to produce a public-only xkey from the given encoded public key string
+    pub fn from_public_key(source: &str) -> Result<Self> {
+        let source_bytes = source.as_bytes();
+        let raw = decode_raw(source_bytes)?;
+
+        let (prefix, rest) = raw.split_first().ok_or(err!(VerifyError, "Empty key"))?;
+        if *prefix != PREFIX_BYTE_CURVE {
+            Err(err!(
+                InvalidPrefix,
+                "Not a valid public key prefix: {}",
+                raw[0]
+            ))
+        } else {
+            let public = PublicKey::try_from(rest)
+                .map_err(|_| err!(VerifyError, "Could not read public key"))?;
+
+            Ok(Self {
+                public,
+                secret: None,
+            })
+        }
+    }
+
+    /// Attempts to produce a full xkey pair from the given encoded seed string
+    pub fn from_seed(source: &str) -> Result<Self> {
+        if source.len() != ENCODED_SEED_LENGTH {
+            let l = source.len();
+            return Err(err!(InvalidSeedLength, "Bad seed length: {}", l));
+        }
+
+        let source_bytes = source.as_bytes();
+        let raw = decode_raw(source_bytes)?;
+
+        let b1 = raw[0] & 248;
+        if b1 != PREFIX_BYTE_SEED {
+            return Err(err!(
+                InvalidPrefix,
+                "Incorrect byte prefix: {}",
+                source.chars().next().unwrap()
+            ));
+        }
+
+        let b2 = (raw[0] & 7) << 5 | ((raw[1] & 248) >> 3);
+        if b2 != PREFIX_BYTE_CURVE {
+            return Err(err!(
+                InvalidPrefix,
+                "Expect a cruve, got {:?}",
+                KeyPairType::from(b2)
+            ));
+        }
+
+        let mut seed = [0u8; 32];
+        seed.copy_from_slice(&raw[2..]);
+
+        let secret = SecretKey::from_bytes(seed);
+        Ok(Self {
+            public: secret.public_key(),
+            secret: Some(secret),
+        })
+    }
+
+    /// Attempts to return the encoded, human-readable string for this key pair's seed.
+    /// Remember that this value should be treated as a secret. Do not store it for
+    /// any longer than necessary
+    pub fn seed(&self) -> Result<String> {
+        let Some(secret) = &self.secret else {
+            return Err(err!(IncorrectKeyType, "This keypair has no seed"));
+        };
+
+        Ok(encode_seed(&KeyPairType::Curve, &secret.to_bytes()))
+    }
+
+    /// Returns the encoded, human-readable public key of this key pair
+    pub fn public_key(&self) -> String {
+        encode(&KeyPairType::Curve, self.public.as_bytes())
+    }
+
+    pub fn private_key(&self) -> Result<String> {
+        let Some(secret) = &self.secret else {
+            return Err(err!(IncorrectKeyType, "This keypair has no seed"));
+        };
+
+        Ok(encode_prefix(&[PREFIX_BYTE_PRIVATE], &secret.to_bytes()))
+    }
+
+    /// Returns the type of this key pair.
+    pub fn key_pair_type(&self) -> KeyPairType {
+        KeyPairType::Curve
+    }
+
+    pub fn open(&self, input: &[u8], sender: &Self) -> Result<Vec<u8>> {
+        let nonce_size = <SalsaBox as AeadCore>::NonceSize::to_usize();
+
+        let Some(secret_key) = &self.secret else {
+            return Err(err!(SignatureError, "Cannot open without a private key"));
+        };
+
+        if input.len() <= XKEY_VERSION_V1.len() + nonce_size {
+            return Err(err!(InvalidPayload, "Payload too short"));
+        }
+
+        let Some(input) = input.strip_prefix(XKEY_VERSION_V1) else {
+            return Err(err!(InvalidPrefix, "Cannot open message, wrong version"));
+        };
+
+        let (nonce, input) = input.split_at(nonce_size);
+
+        let b = SalsaBox::new(&sender.public, secret_key);
+        b.decrypt(nonce.into(), input)
+            .map_err(|_| err!(InvalidPayload, "Cannot decrypt payload"))
+    }
+
+    /// Seal is compatible with nacl.Box.Seal() and can be used in similar situations for small
+    /// messages. We generate the nonce from crypto rand by default.
+    pub fn seal(&self, input: &[u8], recipient: &Self) -> Result<Vec<u8>> {
+        self.seal_with_rand(input, recipient, &mut rand::rngs::OsRng)
+    }
+
+    pub fn seal_with_rand(
+        &self,
+        input: &[u8],
+        recipient: &Self,
+        rand: impl CryptoRng + RngCore,
+    ) -> Result<Vec<u8>> {
+        let Some(private_key) = &self.secret else {
+            return Err(err!(SignatureError, "Cannot seal without a private key"));
+        };
+
+        let b = SalsaBox::new(&recipient.public, private_key);
+        let nonce = SalsaBox::generate_nonce(rand);
+        let crypted = b.encrypt(&nonce, input).unwrap(); // Can't fail
+
+        let mut out = Vec::with_capacity(
+            XKEY_VERSION_V1.len()
+                + <SalsaBox as AeadCore>::NonceSize::to_usize()
+                + input.len()
+                + <SalsaBox as AeadCore>::TagSize::to_usize(),
+        );
+        out.extend_from_slice(XKEY_VERSION_V1);
+        out.extend_from_slice(nonce.as_slice());
+        out.extend_from_slice(&crypted);
+
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::ErrorKind;
+    const MESSAGE: &'static [u8] = b"this is super secret";
+
+    #[test]
+    fn seed_encode_decode_round_trip() {
+        let pair = XKey::new();
+        let s = pair.seed().unwrap();
+        let p = pair.public_key();
+
+        let pair2 = XKey::from_seed(s.as_str()).unwrap();
+        let s2 = pair2.seed().unwrap();
+
+        assert_eq!(s, s2);
+        assert_eq!(p, pair2.public_key());
+    }
+
+    #[test]
+    fn roundtrip_encoding_go_compat() {
+        // Seed and Public Key pair generated by Go nkeys library
+        let seed = "SXAKIYZX2POLIHZ5W5YZEWVTH24NLEUETBW3TKIVYRSS3GNHFXO5D4JJZM";
+        let pk = "XBUJMZHVOPQ2SK5VD3TY4VNBPVU2YFGRLK6EFPEPSMVDUYEBSROWZCEA";
+
+        let pair = XKey::from_seed(seed).unwrap();
+
+        assert_eq!(pair.seed().unwrap(), seed);
+        assert_eq!(pair.public_key(), pk);
+    }
+
+    #[test]
+    fn from_seed_rejects_bad_prefix() {
+        let seed = "FAAPN4W3EG6KCJGUQTKTJ5GSB5NHK5CHAJL4DBGFUM3HHROI4XUEP4OBK4";
+        let pair = XKey::from_seed(seed);
+        assert!(pair.is_err());
+        if let Err(e) = pair {
+            assert_eq!(e.kind(), ErrorKind::InvalidPrefix);
+        }
+    }
+
+    #[test]
+    fn from_seed_rejects_bad_length() {
+        let seed = "SXAKIYZX2POLIHZ5W5YZEWVTH24NLEUETBW3TKIVYRSS3GNHFXO5D4JJZMA";
+        let pair = XKey::from_seed(seed);
+        assert!(pair.is_err());
+        if let Err(e) = pair {
+            assert_eq!(e.kind(), ErrorKind::InvalidSeedLength);
+        }
+    }
+
+    #[test]
+    fn from_seed_rejects_invalid_encoding() {
+        let badseed = "SXAKIYZX2POLIHZ5W5YZEWVTH24NLEUETBW3TKIVYRSS!GNHFXO5D4JJZM";
+        let pair = XKey::from_seed(badseed);
+        assert!(pair.is_err());
+        if let Err(e) = pair {
+            assert_eq!(e.kind(), ErrorKind::CodecFailure);
+        }
+    }
+
+    #[test]
+    fn public_key_round_trip() {
+        let src_pk = "XBUJMZHVOPQ2SK5VD3TY4VNBPVU2YFGRLK6EFPEPSMVDUYEBSROWZCEA";
+        let account = XKey::from_public_key(src_pk).unwrap();
+        let pk = account.public_key();
+        assert_eq!(pk, src_pk);
+    }
+
+    #[test]
+    fn has_proper_prefix() {
+        let module = XKey::new();
+        assert!(module.seed().unwrap().starts_with("SX"));
+        assert!(module.public_key().starts_with('X'));
+    }
+
+    #[test]
+    fn xkeys_convert_to_public() {
+        let sender_pub =
+            XKey::from_public_key("XBUJMZHVOPQ2SK5VD3TY4VNBPVU2YFGRLK6EFPEPSMVDUYEBSROWZCEA")
+                .unwrap();
+        let sender =
+            XKey::from_seed("SXAKIYZX2POLIHZ5W5YZEWVTH24NLEUETBW3TKIVYRSS3GNHFXO5D4JJZM").unwrap();
+
+        assert_eq!(sender.public_key(), sender_pub.public_key());
+    }
+
+    #[test]
+    fn seal_and_open() {
+        let sender = XKey::new();
+        let receiver = XKey::new();
+
+        let boxed = sender.seal(MESSAGE, &receiver).unwrap();
+
+        let res = receiver.open(&boxed, &sender).unwrap();
+        assert_eq!(MESSAGE, res.as_slice());
+    }
+
+    #[test]
+    fn tamper_version() {
+        let sender = XKey::new();
+        let receiver = XKey::new();
+
+        let mut boxed = sender.seal(MESSAGE, &receiver).unwrap();
+
+        // Tamper with message
+        boxed[0] += 1;
+
+        let err = receiver.open(&boxed, &sender).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidPrefix);
+    }
+
+    #[test]
+    fn tamper_message() {
+        let sender = XKey::new();
+        let receiver = XKey::new();
+
+        let mut boxed = sender.seal(MESSAGE, &receiver).unwrap();
+
+        // Tamper with message
+        boxed[XKEY_VERSION_V1.len() + 1] += 1;
+
+        let err = receiver.open(&boxed, &sender).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidPayload);
+    }
+
+    #[test]
+    fn wrong_key() {
+        let sender = XKey::new();
+        let receiver = XKey::new();
+        let random_key = XKey::new();
+
+        let boxed = sender.seal(MESSAGE, &receiver).unwrap();
+
+        let err = random_key.open(&boxed, &sender).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidPayload);
+    }
+
+    #[test]
+    fn open_from_go() {
+        let receiver =
+            XKey::from_seed("SXAHGC56LJFTSRXFC653AT7XZU6WGYIXU4XFPMCT62GGHFLUCSPVYP764M").unwrap();
+        let sender =
+            XKey::from_public_key("XBUJMZHVOPQ2SK5VD3TY4VNBPVU2YFGRLK6EFPEPSMVDUYEBSROWZCEA")
+                .unwrap();
+        let raw_sender =
+            XKey::from_seed("SXAKIYZX2POLIHZ5W5YZEWVTH24NLEUETBW3TKIVYRSS3GNHFXO5D4JJZM").unwrap();
+        assert_eq!(sender.public_key(), raw_sender.public_key());
+
+        // Message generated with nkeys Go library
+        let boxed = [
+            0x78, 0x6b, 0x76, 0x31, 0x46, 0x76, 0x98, 0xf9, 0x87, 0x3, 0x50, 0x2f, 0x42, 0x41,
+            0xb7, 0xa7, 0x34, 0x72, 0x98, 0x0, 0x92, 0x9f, 0x6d, 0x9, 0x4b, 0x6, 0xc6, 0xe3, 0x4a,
+            0x78, 0xde, 0x49, 0x9e, 0xe7, 0xde, 0xbb, 0xac, 0x94, 0x77, 0x55, 0x6f, 0x3f, 0xbb,
+            0xe9, 0xf, 0xfd, 0x67, 0x8b, 0xc6, 0x29, 0xe5, 0xb7, 0xcc, 0x7c, 0x57, 0x40, 0x4d,
+            0x92, 0x38, 0x46, 0xcf, 0x1, 0x2, 0x26,
+        ];
+
+        let out = receiver.open(&boxed, &raw_sender).unwrap();
+        assert_eq!(std::str::from_utf8(&out), Ok("this is super secret"));
+    }
+}


### PR DESCRIPTION
## Feature
Add support for xKeys / curve keys.

This allows to implement a NATS [Auth Callout](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_callout) service in Rust.

## Related Issues

## Release Information
next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->
This PR add a new dependency: [crypto_box](https://github.com/RustCrypto/nacl-compat/tree/master/crypto_box) from RustCrypto, but only behind a feature (not enabled by default).

Without the feature, no visible changes are expected.

## Testing


### Unit Test(s)
I mirrored the relevant test from `KeyPair` to `XKey`

### Acceptance or Integration

### Manual Verification
I implemented a simple auth callout service in Rust against a NATS server (at least version 2.10.4 is required because of https://github.com/advisories/GHSA-mr45-rx8q-wcm9)
