### PR TITLE
fix(crc): avoid integer underflow for empty CRC data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,7 +333,7 @@ impl KeyPair {
 fn decode_raw(raw: &[u8]) -> Result<Vec<u8>> {
     let mut b32_decoded = data_encoding::BASE32_NOPAD.decode(raw)?;
 
-    let checksum = extract_crc(&mut b32_decoded);
+    let checksum = extract_crc(&mut b32_decoded)?;
     let v_checksum = valid_checksum(&b32_decoded, checksum);
     if !v_checksum {
         Err(err!(ChecksumFailure, "Checksum mismatch"))


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

Empty data being fed to the `extract_crc` function causes an integer underflow and resulting `panic` when used in downstream projects.

While the data being empty
int the first place is a somewhat pathological issue and suggests a problem with external tooling/downstream users, we can easily avoid `panic`s in the case of that pathological case.

This commit updates the CRC parsing code to account for the possibility that provided data is empty.

Related: https://github.com/wasmCloud/wasmCloud/issues/1103

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
