### PR TITLE
Fix/add length check

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -28,8 +28,8 @@ pub struct Error {
 pub enum ErrorKind {
     /// Indicates an inappropriate byte prefix was used for an encoded key string
     InvalidPrefix,
-    /// Indicates a seed key string was used with the wrong length
-    InvalidSeedLength,
+    /// Indicates a key string was used with the wrong length
+    InvalidKeyLength,
     /// Indicates a signature verification mismatch. Use this to check for invalid signatures or messages
     VerifyError,
     /// Indicates an unexpected underlying error occurred while trying to perform routine signature tasks.
@@ -63,7 +63,7 @@ impl ErrorKind {
     pub fn as_str(self) -> &'static str {
         match self {
             ErrorKind::InvalidPrefix => "Invalid byte prefix",
-            ErrorKind::InvalidSeedLength => "Invalid seed length",
+            ErrorKind::InvalidKeyLength => "Invalid key length",
             ErrorKind::VerifyError => "Signature verification failure",
             ErrorKind::ChecksumFailure => "Checksum match failure",
             ErrorKind::CodecFailure => "Codec failure",
@@ -135,12 +135,12 @@ mod tests {
     #[test]
     fn test_error_to_string() {
         assert_eq!(
-            err!(InvalidSeedLength, "Testing").to_string(),
-            "Invalid seed length: Testing"
+            err!(InvalidKeyLength, "Testing").to_string(),
+            "Invalid key length: Testing"
         );
         assert_eq!(
-            err!(InvalidSeedLength, "Testing {}", 1).to_string(),
-            "Invalid seed length: Testing 1"
+            err!(InvalidKeyLength, "Testing {}", 1).to_string(),
+            "Invalid key length: Testing 1"
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,7 +346,7 @@ fn decode_raw(raw: &[u8]) -> Result<Vec<u8>> {
 fn from_seed(source: &str) -> Result<(u8, [u8; 32])> {
     if source.len() != ENCODED_SEED_LENGTH {
         let l = source.len();
-        return Err(err!(InvalidSeedLength, "Bad seed length: {}", l));
+        return Err(err!(InvalidKeyLength, "Bad seed length: {}", l));
     }
 
     let source_bytes = source.as_bytes();
@@ -475,7 +475,7 @@ mod tests {
         let pair = KeyPair::from_seed(seed);
         assert!(pair.is_err());
         if let Err(e) = pair {
-            assert_eq!(e.kind(), ErrorKind::InvalidSeedLength);
+            assert_eq!(e.kind(), ErrorKind::InvalidKeyLength);
         }
     }
 

--- a/src/xkeys.rs
+++ b/src/xkeys.rs
@@ -250,7 +250,7 @@ mod tests {
         let pair = XKey::from_seed(seed);
         assert!(pair.is_err());
         if let Err(e) = pair {
-            assert_eq!(e.kind(), ErrorKind::InvalidSeedLength);
+            assert_eq!(e.kind(), ErrorKind::InvalidKeyLength);
         }
     }
 


### PR DESCRIPTION
## Feature or Problem
Update `from_public_key` to check that the input string is of the expected length before calling `decode_raw`

This is a breaking change, since I renamed `InvalidSeedLength` to `InvalidKeyLength`, to use for either seeds or public keys

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
v0.5.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
Added a unit test

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
