### PR TITLE
chore: drop byteorder dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ ed25519-dalek = { version = "2.0.0", default-features = false, features = [
     "digest",
 ] }
 rand = "0.8"
-byteorder = "1.3.4"
 data-encoding = "2.3.0"
 log = "0.4.11"
 crypto_box = { version = "0.9.1", optional = true } # For xKeys support


### PR DESCRIPTION
## Feature or Problem

Drop the `byteorder` dependency, which could easily be replaced with functions from std and easier to read logic.

## Related Issues

None

## Release Information

next

## Consumer Impact

One less dependency, and less `unsafe` code in the build

## Testing

Read below

### Unit Test(s)

None

### Acceptance or Integration

None

### Manual Verification

While manually verifying that the code is correct I've gotten even more confused at how this code works. Looking at the Go library the CRC is put at the end and read from the end, while here the CRC is written to the end and read from the start :man_shrugging:. Are the tests wrong???

I've tried doing this and this seems to confirm my assumption:

```diff
diff --git a/src/crc.rs b/src/crc.rs
index 228880d..5dc5981 100644
--- a/src/crc.rs
+++ b/src/crc.rs
@@ -58,3 +58,23 @@ pub(crate) fn extract_crc(data: &mut Vec<u8>) -> Result<u16> {
     data.truncate(data.len() - 2);
     Ok(crc)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::crc::crc16;
+
+    use super::{extract_crc, push_crc};
+
+    #[test]
+    fn im_confused() {
+        let raw_data = rand::random::<[u8; 32]>();
+        let crc = crc16(&raw_data);
+
+        let mut data = raw_data.to_vec();
+        push_crc(&mut data);
+
+        let crc2 = extract_crc(&mut data).unwrap();
+        assert_eq!(raw_data, data.as_slice());
+        assert_eq!(crc, crc2);
+    }
+}
```
