### PR TITLE
feat: Add support for converting KeyPairs into JWKs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ cli = [
 
 xkeys = ["dep:crypto_box"]
 
+jwk = ["serde", "serde_json", "sha2"]
+
 [[bin]]
 name = "nk"
 required-features = ["cli"]
@@ -46,6 +48,10 @@ term-table = { version = "1.3.0", optional = true }
 exitfailure = { version = "0.5.1", optional = true }
 env_logger = { version = "0.9", optional = true }
 serde_json = { version = "1.0", optional = true }
+
+# jwk dependencies
+serde = { version = "1.0", optional = true, features = ["derive"] }
+sha2 = { version = "0.10", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # NOTE: We need this due to an underlying dependency being pulled in by

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,8 @@ pub enum ErrorKind {
     IncorrectKeyType,
     /// Payload not valid (or failed to be decrypted)
     InvalidPayload,
+    /// Thumbprint could not be calculated over the provided public key value
+    ThumbprintCalculationFailure,
 }
 
 /// A handy macro borrowed from the `signatory` crate that lets library-internal code generate
@@ -70,6 +72,7 @@ impl ErrorKind {
             ErrorKind::SignatureError => "Signature failure",
             ErrorKind::IncorrectKeyType => "Incorrect key type",
             ErrorKind::InvalidPayload => "Invalid payload",
+            ErrorKind::ThumbprintCalculationFailure => "Thumbprint calculation failure",
         }
     }
 }

--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -1,0 +1,151 @@
+use std::collections::BTreeMap;
+
+use crate::{err, from_public_key, from_seed, KeyPair, KeyPairType, Result};
+use data_encoding::BASE64URL_NOPAD;
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+// We hard code the value here, because we're using Edwards-curve keys, which OKP represents:
+// https://datatracker.ietf.org/doc/html/draft-ietf-jose-cfrg-curves-06#section-2
+const JWK_KEY_TYPE: &str = "OKP";
+// https://datatracker.ietf.org/doc/html/draft-ietf-jose-cfrg-curves-06#section-3.1
+const JWK_ALGORITHM: &str = "EdDSA";
+const JWK_SUBTYPE: &str = "Ed25519";
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JsonWebKey {
+    /// Intended use of the JWK, this is based on the KeyPairType of the KeyPair the JWK is based on, using "enc" for KeyPairType::Curve, otherwise "sig"
+    #[serde(rename = "use")]
+    intended_use: String,
+    /// Key type, which we default to OKP (Octet Key Pair) to represent Edwards-curve keys
+    #[serde(rename = "kty")]
+    key_type: String,
+    /// Key ID, which will be represented by the thumbprint calculated over the subtype (crv), key_type (kty) and public_key (x) components of the JWK.
+    /// See https://datatracker.ietf.org/doc/html/rfc7639 for more details.
+    #[serde(rename = "kid")]
+    key_id: String,
+    /// Algorithm used for the JWK, defaults to EdDSA
+    #[serde(rename = "alg")]
+    algorithm: String,
+    /// Subtype of the key (from the "JSON Web Elliptic Curve" registry)
+    #[serde(rename = "crv")]
+    subtype: String,
+    // Public key value encoded using base64url encoding
+    #[serde(rename = "x")]
+    public_key: String,
+    // Private key value, if provided, encoded using base64url encoding
+    #[serde(rename = "d", skip_serializing_if = "Option::is_none")]
+    private_key: Option<String>,
+}
+
+impl JsonWebKey {
+    pub fn from_seed(source: &str) -> Result<Self> {
+        let (prefix, seed) = from_seed(source)?;
+        let sk = SigningKey::from_bytes(&seed);
+        let kp_type = &KeyPairType::from(prefix);
+        let public_key = BASE64URL_NOPAD.encode(sk.verifying_key().as_bytes());
+        let thumbprint = Self::calculate_thumbprint(&public_key)?;
+
+        Ok(JsonWebKey {
+            intended_use: Self::intended_use_for_key_pair_type(kp_type),
+            key_id: thumbprint,
+            public_key,
+            private_key: Some(BASE64URL_NOPAD.encode(sk.as_bytes())),
+            ..Default::default()
+        })
+    }
+
+    pub fn from_public_key(source: &str) -> Result<Self> {
+        let (prefix, bytes) = from_public_key(source)?;
+        let vk = VerifyingKey::from_bytes(&bytes)?;
+        let public_key = BASE64URL_NOPAD.encode(vk.as_bytes());
+        let thumbprint = Self::calculate_thumbprint(&public_key)?;
+
+        Ok(JsonWebKey {
+            intended_use: Self::intended_use_for_key_pair_type(&KeyPairType::from(prefix)),
+            key_id: thumbprint,
+            public_key,
+            ..Default::default()
+        })
+    }
+
+    fn intended_use_for_key_pair_type(typ: &KeyPairType) -> String {
+        match typ {
+            KeyPairType::Server
+            | KeyPairType::Cluster
+            | KeyPairType::Operator
+            | KeyPairType::Account
+            | KeyPairType::User
+            | KeyPairType::Module
+            | KeyPairType::Service => "sig".to_owned(),
+            KeyPairType::Curve => "enc".to_owned(),
+        }
+    }
+
+    /// For details on how fingerprints are calculated, see: https://datatracker.ietf.org/doc/html/rfc7638#section-3.1
+    /// For OKP specific details, see https://datatracker.ietf.org/doc/html/draft-ietf-jose-cfrg-curves-06#appendix-A.3
+    pub fn calculate_thumbprint(public_key: &str) -> Result<String> {
+        // We use BTreeMap here, because the order needs to be lexicographically sorted:
+        // https://datatracker.ietf.org/doc/html/rfc7638#section-3.3
+        let components = BTreeMap::from([
+            ("crv", JWK_SUBTYPE),
+            ("kty", JWK_KEY_TYPE),
+            ("x", public_key),
+        ]);
+        let value = json!(components);
+        let mut bytes: Vec<u8> = Vec::new();
+        serde_json::to_writer(&mut bytes, &value).map_err(|_| {
+            err!(
+                ThumbprintCalculationFailure,
+                "unable to serialize public key"
+            )
+        })?;
+        let mut hasher = Sha256::new();
+        hasher.update(&*bytes);
+        let hash = hasher.finalize();
+        Ok(BASE64URL_NOPAD.encode(&hash))
+    }
+}
+
+impl Default for JsonWebKey {
+    fn default() -> Self {
+        Self {
+            intended_use: Default::default(),
+            key_type: JWK_KEY_TYPE.to_string(),
+            key_id: Default::default(),
+            algorithm: JWK_ALGORITHM.to_string(),
+            subtype: JWK_SUBTYPE.to_string(),
+            public_key: Default::default(),
+            private_key: None,
+        }
+    }
+}
+
+impl TryFrom<KeyPair> for JsonWebKey {
+    type Error = crate::error::Error;
+
+    fn try_from(value: KeyPair) -> Result<Self> {
+        if let Ok(seed) = value.seed() {
+            Ok(Self::from_seed(&seed)?)
+        } else {
+            Ok(Self::from_public_key(&value.public_key())?)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Using the example values from https://datatracker.ietf.org/doc/html/draft-ietf-jose-cfrg-curves-06#appendix-A.3
+    #[test]
+    fn calculate_thumbprint_provides_correct_thumbprint() {
+        let input_public_key = "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo";
+        let expected_thumbprint = "kPrK_qmxVWaYVA9wwBF6Iuo3vVzz7TxHCTwXBygrS4k";
+        let actual_thumbprint = JsonWebKey::calculate_thumbprint(input_public_key).unwrap();
+
+        assert_eq!(expected_thumbprint, actual_thumbprint);
+    }
+}


### PR DESCRIPTION
## Feature or Problem

While implementing a Secrets backend for https://github.com/wasmCloud/wasmCloud/issues/2190, we landed on JWTs as the authentication mechanism, and since we have nkeys readily available, it would be nice to use them for signing the JWTs.

However, to make it easier on the platform operators, we are not going to require them to provide a static list of the possible public keys used for signing, but instead provide a JWKS endpoint that'll host a list of the public nkeys used to sign the JWT.

It turns out it's pretty straight forward to convert an nkey into a JWK, which is why I thought it would be nice to add as a feature to this crate for other folks to use as well.

cc @protochron 

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->

I validated locally using [`jose-util` from the `go-jose` project](https://github.com/go-jose/go-jose/tree/main/jose-util) that the keys generated with the new `JsonWebkey` struct, based on a pre-existing nkey, can be used to sign (with seed) and verify (with public key) payloads correctly:
```shell
# Using jose-util built from the main branch (i.e. v4)
$ echo "test message v4" > msg-v4.txt
$ jose-util sign -alg EdDSA -key private.jwk.json -in msg.txt -out signed-msg-v4.txt
$ jose-util verify -key public.jwk.json -in signed-msg-v4.txt
test message v4

# Using jose-util built from the v3.0.3 branch
$ echo "test message v3" > msg-v3.txt
$ jose-util sign --alg=EdDSA --key=private.jwk.json --in=msg-v3.txt > signed-msg-v3.txt
$ jose-util verify --key=public.jwk.json --in=signed-msg-v3.txt
test message v3
```