### PR TITLE
fix: from_seed_rejects_bad_prefix test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,4 +30,4 @@ jobs:
       - name: Format check
         run: cargo fmt --all -- --check
       - name: Test
-        run: cargo test
+        run: cargo test --all-features

--- a/src/xkeys.rs
+++ b/src/xkeys.rs
@@ -236,7 +236,7 @@ mod tests {
 
     #[test]
     fn from_seed_rejects_bad_prefix() {
-        let seed = "FAAPN4W3EG6KCJGUQTKTJ5GSB5NHK5CHAJL4DBGFUM3HHROI4XUEP4OBK4";
+        let seed = "SZAIB67JMUPS5OKP6BZNCFTIMHOTS6JIX2C53TLSNEROIRFBJLSK3NUOVY";
         let pair = XKey::from_seed(seed);
         assert!(pair.is_err());
         if let Err(e) = pair {


### PR DESCRIPTION
## Feature or Problem

While developing #33 and running the tests, I noticed that [one of the tests from xkeys](https://github.com/wasmCloud/nkeys/blob/master/src/xkeys.rs#L238-L245) was failing, presumably as a result of the improvements made in https://github.com/wasmCloud/nkeys/pull/31, and it wasn't caught in the original PR due to the fact that we weren't running the tests against all of the features.

This fixes up the test and makes our CI actually run all of the tests.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
