### PR TITLE
chore: Address clippy lints for XKeys

### DIFF
--- a/src/xkeys.rs
+++ b/src/xkeys.rs
@@ -203,11 +203,18 @@ impl XKey {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+impl Default for XKey {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::error::ErrorKind;
-    const MESSAGE: &'static [u8] = b"this is super secret";
+    const MESSAGE: &[u8] = b"this is super secret";
 
     #[test]
     fn seed_encode_decode_round_trip() {


### PR DESCRIPTION
## Feature or Problem

While looking through the XKeys implementation I noticed some outstanding lints ([new without default](new_without_default), [redundant static lifetimes](https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_static_lifetimes)) that were easy enough to address.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
