### PR TITLE
feat: Add support for converting KeyPair with seed to PKCS 8 DER format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ xkeys = ["dep:crypto_box"]
 
 jwk = ["serde", "serde_json", "sha2"]
 
+pkcs8 = ["dep:pkcs8", "ed25519-dalek/pkcs8", "ed25519-dalek/alloc"]
+
 [[bin]]
 name = "nk"
 required-features = ["cli"]
@@ -52,6 +54,9 @@ serde_json = { version = "1.0", optional = true }
 # jwk dependencies
 serde = { version = "1.0", optional = true, features = ["derive"] }
 sha2 = { version = "0.10", optional = true }
+
+# pkcs8 dependencies
+pkcs8 = { version = "0.10", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # NOTE: We need this due to an underlying dependency being pulled in by

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,12 @@ pub enum ErrorKind {
     InvalidPayload,
     /// Thumbprint could not be calculated over the provided public key value
     ThumbprintCalculationFailure,
+    /// SigningKey could not be converted converted to PKCS 8 DER format
+    #[cfg(feature = "pkcs8")]
+    Pkcs8ConversionFailure,
+    /// PKCS 8 DER conversion was called on a keypair that does not have a Signing Key
+    #[cfg(feature = "pkcs8")]
+    MissingSigningKey,
 }
 
 /// A handy macro borrowed from the `signatory` crate that lets library-internal code generate
@@ -73,6 +79,10 @@ impl ErrorKind {
             ErrorKind::IncorrectKeyType => "Incorrect key type",
             ErrorKind::InvalidPayload => "Invalid payload",
             ErrorKind::ThumbprintCalculationFailure => "Thumbprint calculation failure",
+            #[cfg(feature = "pkcs8")]
+            ErrorKind::Pkcs8ConversionFailure => "PKCS 8 Conversion Failure",
+            #[cfg(feature = "pkcs8")]
+            ErrorKind::MissingSigningKey => "Missing Signing Key",
         }
     }
 }


### PR DESCRIPTION
## Feature or Problem

This adds the ability to convert a KeyPair that was created from/with a seed into PKCS 8 DER format, which is useful for passing into other libraries.

As an aside, I would've loved to have simply implemented [`pkcs8::EncodePrivateKey`](https://github.com/RustCrypto/formats/blob/master/pkcs8/src/traits.rs#L95-L99) trait, but sadly with the underlying signing key being behind an Option, I think it would make that trait implementation a little more cumbersome than it needs to be, so I decided to just add a method with the same name into the KeyPair impl.

If there's a better way to do this, I'd be happy to adjust the approach :)

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
