### PR TITLE
feat: Expose decode_seed functionality

### DIFF
--- a/src/jwk.rs
+++ b/src/jwk.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use crate::{err, from_public_key, from_seed, KeyPair, KeyPairType, Result};
+use crate::{decode_seed, err, from_public_key, KeyPair, KeyPairType, Result};
 use data_encoding::BASE64URL_NOPAD;
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use serde::{Deserialize, Serialize};
@@ -42,7 +42,7 @@ pub struct JsonWebKey {
 
 impl JsonWebKey {
     pub fn from_seed(source: &str) -> Result<Self> {
-        let (prefix, seed) = from_seed(source)?;
+        let (prefix, seed) = decode_seed(source)?;
         let sk = SigningKey::from_bytes(&seed);
         let kp_type = &KeyPairType::from(prefix);
         let public_key = BASE64URL_NOPAD.encode(sk.verifying_key().as_bytes());

--- a/src/xkeys.rs
+++ b/src/xkeys.rs
@@ -1,6 +1,6 @@
 use crate::{
-    decode_raw, encode, encode_prefix, encode_seed, err, from_seed, KeyPairType, PREFIX_BYTE_CURVE,
-    PREFIX_BYTE_PRIVATE,
+    decode_raw, decode_seed, encode, encode_prefix, encode_seed, err, KeyPairType,
+    PREFIX_BYTE_CURVE, PREFIX_BYTE_PRIVATE,
 };
 
 use super::Result;
@@ -86,7 +86,7 @@ impl XKey {
 
     /// Attempts to produce a full xkey pair from the given encoded seed string
     pub fn from_seed(source: &str) -> Result<Self> {
-        let (ty, seed) = from_seed(source)?;
+        let (ty, seed) = decode_seed(source)?;
 
         if ty != PREFIX_BYTE_CURVE {
             return Err(err!(


### PR DESCRIPTION
## Feature or Problem

This renames and exposes pre-existing `from_seed` function as `decode_seed` to mirror the Go nkeys library's [`DecodeSeed`](https://pkg.go.dev/github.com/nats-io/nkeys#DecodeSeed) functionality.

Depending on whether we would prefer to provide higher level abstractions or stick closer to the spiritual implementation of the Go library's implementation, I realize there may be preference to provide access to the underlying `SigningKey`, which could work just as well, it just creates the need for an unnecessary step of having to first create a KeyPair from the seed, only to then turn it into something else.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
