### PR TITLE
fix: Catch invalid signature length when verifying signature

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,8 @@ pub enum ErrorKind {
     InvalidPayload,
     /// Thumbprint could not be calculated over the provided public key value
     ThumbprintCalculationFailure,
+    /// Signature did not match the expected length (64 bytes)
+    InvalidSignatureLength,
 }
 
 /// A handy macro borrowed from the `signatory` crate that lets library-internal code generate
@@ -66,6 +68,7 @@ impl ErrorKind {
         match self {
             ErrorKind::InvalidPrefix => "Invalid byte prefix",
             ErrorKind::InvalidKeyLength => "Invalid key length",
+            ErrorKind::InvalidSignatureLength => "Invalid signature length",
             ErrorKind::VerifyError => "Signature verification failure",
             ErrorKind::ChecksumFailure => "Checksum match failure",
             ErrorKind::CodecFailure => "Codec failure",


### PR DESCRIPTION
## Feature or Problem

Addresses the example described in #13 where wrong length would cause the `verify` method to panic.

## Related Issues

Closes #13 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
