### PR TITLE
feat: derive Clone for KeyPair and XKey

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,8 @@ const PUBLIC_KEY_PREFIXES: [u8; 8] = [
 type Result<T> = std::result::Result<T, crate::error::Error>;
 
 /// The main interface used for reading and writing _nkey-encoded_ key pairs, including
-/// seeds and public keys. Instances of this type cannot be cloned.
+/// seeds and public keys.
+#[derive(Clone)]
 pub struct KeyPair {
     kp_type: KeyPairType,
     sk: Option<SecretKey>, //rawkey_kind: RawKeyKind,

--- a/src/xkeys.rs
+++ b/src/xkeys.rs
@@ -17,7 +17,8 @@ use crypto_box::{PublicKey, SecretKey};
 use rand::{CryptoRng, Rng, RngCore};
 
 /// The main interface used for reading and writing _nkey-encoded_ curve key
-/// pairs. Instances of this type cannot be cloned.
+/// pairs.
+#[derive(Clone)]
 pub struct XKey {
     public: PublicKey,
     secret: Option<SecretKey>,


### PR DESCRIPTION
## Feature or Problem
Allow KeyPair and XKey structs to be cloned. We have no technical reason not to do this, since it is trivial to copy out a private key from either key type and the underlying members of the struct are all already Clone.


## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
