### PR TITLE
feat: upgrade `ed25519` to `2.2.3`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ required-features = ["cli"]
 
 [dependencies]
 signatory = "0.27"
-ed25519 = { version = "2.0.0", default-features = false }
+ed25519 = { version = "2.2.3", default-features = false }
 ed25519-dalek = { version = "2.0.0", default-features = false, features = [
     "digest",
 ] }


### PR DESCRIPTION
## Feature or Problem

I'm working on some things for https://github.com/vectordotdev/vector when I noticed a dependency conflict that came from `nkeys`. This was resolved by bumping `ed25519` from `2.0.0` to `2.2.3`.

CHANGELOG: https://github.com/RustCrypto/signatures/blob/master/ed25519/CHANGELOG.md

as the per the changelog, there were no notable changes to `ed25519` that will affect this repo. Upgrading to `2.2.3` also aligns onto `ed25519-dalek` `2.x` as a common shared dep.

Would appreciate if we could merge this in to unblock future work on vector. Thanks!

Full error message:

```
error: failed to select a version for `der`.
    ... required by package `ureq v3.0.11`
    ... which satisfies dependency `ureq = "^3.0.11"` of package `sentry v0.41.0`
    ... which satisfies dependency `sentry = "^0.41.0"` (locked to 0.41.0) of package `vector v0.49.0 (/Users/abhijeetprasad/workspace/vector)`
versions that meet the requirements `^0.7.9` are: 0.7.10, 0.7.9

all possible versions conflict with previously selected packages.

  previously selected package `der v0.7.8`
    ... which satisfies dependency `der = "^0.7"` (locked to 0.7.8) of package `pkcs8 v0.10.2`
    ... which satisfies dependency `pkcs8 = "^0.10"` (locked to 0.10.2) of package `ed25519 v2.2.3`
    ... which satisfies dependency `ed25519 = "^2.0.0"` (locked to 2.2.3) of package `nkeys v0.4.4`
    ... which satisfies dependency `nkeys = "^0.4.4"` (locked to 0.4.4) of package `vector v0.49.0 (/Users/abhijeetprasad/workspace/vector)`
```