### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ categories = ["cryptography", "authentication"]
 
 [features]
 cli = [
-    "quicli",
-    "structopt",
+    "clap",
     "term-table",
     "exitfailure",
     "env_logger",
@@ -33,21 +32,20 @@ required-features = ["cli"]
 
 [dependencies]
 signatory = "0.27"
-ed25519 = { version = "2.2.3", default-features = false }
-ed25519-dalek = { version = "2.0.0", default-features = false, features = [
+ed25519 = { version = "3.0.0", default-features = false }
+ed25519-dalek = { version = "3.0.0", default-features = false, features = [
     "digest",
 ] }
-rand = "0.8"
+rand = "0.10.2"
 data-encoding = "2.3.0"
 log = "0.4.11"
 crypto_box = { version = "0.9.1", optional = true } # For xKeys support
 
 # CLI Dependencies
-quicli = { version = "0.4", optional = true }
-structopt = { version = "0.3.17", optional = true }
+clap = { version = "4", features = ["derive"], optional = true }
 term-table = { version = "1.3.0", optional = true }
 exitfailure = { version = "0.5.1", optional = true }
-env_logger = { version = "0.9", optional = true }
+env_logger = { version = "0.11.11", optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/bin/nk/main.rs
+++ b/src/bin/nk/main.rs
@@ -1,33 +1,27 @@
 extern crate serde_json;
 
+use clap::{Parser, Subcommand};
 use nkeys::{self, KeyPair, KeyPairType};
 use serde_json::json;
 use std::error::Error;
 use std::fmt;
 use std::str::FromStr;
-use structopt::clap::AppSettings;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt, Clone)]
-#[structopt(
-    global_settings(&[AppSettings::ColoredHelp, AppSettings::VersionlessSubcommands]),
-    name = "nk",
-    about = "A tool for manipulating nkeys"
-)]
+#[derive(Parser, Debug, Clone)]
+#[command(name = "nk", about = "A tool for manipulating nkeys")]
 struct Cli {
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     cmd: Command,
 }
 
-#[derive(StructOpt, Debug, Clone)]
+#[derive(Subcommand, Debug, Clone)]
 enum Command {
-    #[structopt(name = "gen", about = "Generates a key pair")]
+    /// Generates a key pair
     Gen {
         /// The type of key pair to generate. May be Account, User, Module, Service, Server, Operator, Cluster, Curve (xkey)
-        #[structopt(case_insensitive = true)]
         keytype: KeyPairType,
-        #[structopt(
-            short = "o",
+        #[arg(
+            short = 'o',
             long = "output",
             default_value = "text",
             help = "Specify output format (text or json)"
@@ -36,7 +30,7 @@ enum Command {
     },
 }
 
-#[derive(StructOpt, Debug, Clone)]
+#[derive(Debug, Clone)]
 enum Output {
     Text,
     Json,
@@ -69,7 +63,7 @@ impl fmt::Display for OutputParseErr {
 }
 
 fn main() {
-    let args = Cli::from_args();
+    let args = Cli::parse();
     let cmd = &args.cmd;
     env_logger::init();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,7 @@ impl KeyPair {
 
         match self.pk.verify(input, &insig) {
             Ok(()) => Ok(()),
-            Err(e) => Err(e.into()),
+            Err(e) => Err(err!(SignatureError, "{}", e)),
         }
     }
 
@@ -396,8 +396,8 @@ pub fn decode_seed(source: &str) -> Result<(u8, [u8; 32])> {
 }
 
 fn generate_seed_rand() -> [u8; 32] {
-    let mut rng = rand::thread_rng();
-    rng.gen::<[u8; 32]>()
+    let mut rng = rand::rng();
+    rng.random::<[u8; 32]>()
 }
 
 fn get_prefix_byte(kp_type: &KeyPairType) -> u8 {

--- a/src/xkeys.rs
+++ b/src/xkeys.rs
@@ -14,7 +14,7 @@ use std::fmt::{self, Debug};
 const XKEY_VERSION_V1: &[u8] = b"xkv1";
 
 use crypto_box::{PublicKey, SecretKey};
-use rand::{CryptoRng, Rng, RngCore};
+use rand::{CryptoRng, RngExt};
 
 /// The main interface used for reading and writing _nkey-encoded_ curve key
 /// pairs.
@@ -37,7 +37,7 @@ impl XKey {
     /// rand support. Use [`new_from_raw`](XKey::new_from_raw) instead
     #[cfg(not(target_arch = "wasm32"))]
     pub fn new() -> Self {
-        Self::new_with_rand(&mut rand::rngs::OsRng)
+        Self::new_with_rand(&mut rand::rng())
     }
 
     /// Create a new xkey pair from a random generator
@@ -47,8 +47,8 @@ impl XKey {
     /// NOTE: This is not available if using on a wasm32-unknown-unknown target due to the lack of
     /// rand support. Use [`new_from_raw`](XKey::new_from_raw) instead
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn new_with_rand(rand: &mut (impl CryptoRng + RngCore)) -> Self {
-        Self::new_from_raw(rand.gen())
+    pub fn new_with_rand(rand: &mut impl CryptoRng) -> Self {
+        Self::new_from_raw(rand.random())
     }
 
     /// Create a new xkey pair using a pre-existing set of random bytes.
@@ -162,7 +162,7 @@ impl XKey {
     /// rand support. Use [`seal_with_nonce`](XKey::seal_with_nonce) instead
     #[cfg(not(target_arch = "wasm32"))]
     pub fn seal(&self, input: &[u8], recipient: &Self) -> Result<Vec<u8>> {
-        self.seal_with_rand(input, recipient, &mut rand::rngs::OsRng)
+        self.seal_with_rand(input, recipient, rand::rng())
     }
 
     /// NOTE: This is not available if using on a wasm32-unknown-unknown target due to the lack of
@@ -172,9 +172,10 @@ impl XKey {
         &self,
         input: &[u8],
         recipient: &Self,
-        rand: impl CryptoRng + RngCore,
+        mut rand: impl CryptoRng,
     ) -> Result<Vec<u8>> {
-        let nonce = SalsaBox::generate_nonce(rand);
+        let mut nonce = Nonce::default();
+        rand.fill_bytes(&mut nonce[..]);
         self.seal_with_nonce(input, recipient, nonce)
     }
 


### PR DESCRIPTION
## Feature or Problem
Resolves #55

Updates most of the dependencies and replaces structopt (which is no longer maintained) with clap.

https://rustsec.org/advisories/RUSTSEC-2022-0104.html (structopt unmaintained)
https://rustsec.org/advisories/RUSTSEC-2026-0097.html (rand unsoundness)
